### PR TITLE
sticky header

### DIFF
--- a/frontend/src/css/globals.css
+++ b/frontend/src/css/globals.css
@@ -7,6 +7,8 @@
     box-sizing: border-box;
     margin: 0;
     padding: 0;
+    position: sticky;
+    top: 0;
 }
 
 html,


### PR DESCRIPTION
This edit makes the header sticky only for the About and the Contact section.

